### PR TITLE
update discordeno 13 -> 18

### DIFF
--- a/discord/discord.ts
+++ b/discord/discord.ts
@@ -1,14 +1,14 @@
-import { createBot, startBot, Bot } from "https://deno.land/x/discordeno@13.0.0/mod.ts";
+import { createBot, startBot, Bot } from "https://deno.land/x/discordeno@18.0.0/mod.ts";
 import {
   BotWithCache,
   enableCachePlugin,
   enableCacheSweepers
-} from "https://deno.land/x/discordeno@13.0.0/plugins/cache/mod.ts";
+} from "https://deno.land/x/discordeno@18.0.0/plugins/cache/mod.ts";
 import { EventDispatcher } from "./dispatchers/event.ts";
 import { Logger } from "../logging/logger.ts";
 import { InteractionDispatcher } from "./dispatchers/interaction.ts";
 
-export * from "https://deno.land/x/discordeno@13.0.0/mod.ts";
+export * from "https://deno.land/x/discordeno@18.0.0/mod.ts";
 
 export interface DiscordInitOpts {
   token: string;

--- a/discord/interaction/dispatcher.ts
+++ b/discord/interaction/dispatcher.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOption, ApplicationCommandTypes } from "https://deno.land/x/discordeno@13.0.0/mod.ts";
+import { ApplicationCommandOption, ApplicationCommandTypes } from "https://deno.land/x/discordeno@18.0.0/mod.ts";
 import { Discord } from "../discord.ts";
 import { Logger } from "../../logging/logger.ts";
 import { File } from "../../filesystem/file.ts";
@@ -44,7 +44,7 @@ export class InteractionDispatcher {
    */
   public static async update(opts: any): Promise<void> {
     try {
-      await Discord.getBot().helpers.upsertApplicationCommands(InteractionDispatcher.getInteractions(), opts.guildId);
+      await Discord.getBot()?.helpers.upsertGuildApplicationCommands(opts.guildId, InteractionDispatcher.getInteractions());
     } catch(e) {
       Logger.error(`Could not update interactions: ${e.message}`);
     }

--- a/discord/mod.ts
+++ b/discord/mod.ts
@@ -14,8 +14,8 @@ export {
   Intents,
   AuditLogEvents,
   ApplicationCommandFlags
-} from "https://deno.land/x/discordeno@13.0.0/mod.ts";
+} from "https://deno.land/x/discordeno@18.0.0/mod.ts";
 
 export type {
   DiscordEmbed
-} from "https://deno.land/x/discordeno@13.0.0/mod.ts";
+} from "https://deno.land/x/discordeno@18.0.0/mod.ts";


### PR DESCRIPTION
Did as previously described: used local chomp and kept testing and upgrading Edinburgh + chomp until all issues has been fixed (I run most of the commands, all the events)

when running into issues I looked up a possible change here first: https://github.com/discordeno/discordeno/releases

I can't promise that I didn't miss something

(keep in mind some 13 -> 18 upgrades had to happen in Edinburgh directly)